### PR TITLE
Minor CSS fix for unnecessary scrollbar

### DIFF
--- a/src/public/crud/css/list.css
+++ b/src/public/crud/css/list.css
@@ -9,3 +9,8 @@
     padding-left: 15px;
     padding-right: 15px;
 }
+
+#crudTable_wrapper > .row {
+    margin-left:  0;
+    margin-right: 0;
+}


### PR DESCRIPTION
This overrides the Bootstrap .row default CSS that causes the table to always have the horizontal scrollbar showing.

Original Bootstrap CSS:
```
.row {
    margin-right: -15px;
    margin-left: -15px;
}
```

And alternative would be to place all rows inside a '.col'.